### PR TITLE
Add Hanzilla Jobs resource

### DIFF
--- a/resources-data/data.json
+++ b/resources-data/data.json
@@ -62,6 +62,15 @@
       "owner": "Ross Pomerantz",
       "submitted_by": "Ryan McGovern",
       "submitted_on": "Mon, 02 Sep 2024 01:26:13 GMT"
+    },
+    {
+      "name": "Hanzilla Jobs",
+      "outline": "A free daily-updated Canadian student and recent-grad jobs board",
+      "link": "https://jobs.hanzilla.co/internships/",
+      "description": "Hanzilla Jobs collects Canada-specific internships, co-ops, new grad, junior, and entry-level roles across tech, data, finance, engineering, business, sciences, and related fields. It is useful for students and recent graduates who want a no-login board with field, city, and stage pages.",
+      "owner": "Hanzi Li",
+      "submitted_by": "Hanzi Li",
+      "submitted_on": "Sun, 17 May 2026 22:25:42 GMT"
     }
   ],
   "books": [


### PR DESCRIPTION
## Summary
- Add Hanzilla Jobs to the job board resource data set.
- Position it as a free, no-login, Canada-specific board for students and recent grads looking for internships, co-ops, new grad, junior, and entry-level roles.

## Why this fits
Hanzilla Jobs is a maintained job-search resource with field, city, and stage pages. The submitted URL points to the internships/co-ops entry point, which should be useful for students using this resource app.

## Verification
- Parsed `resources-data/data.json` with Python `json.load`.
- Ran `git diff --check`.
